### PR TITLE
fix(bootstrap): Pull secret value instead of key

### DIFF
--- a/packages/plugin/src/modules/Bootstrap.ts
+++ b/packages/plugin/src/modules/Bootstrap.ts
@@ -436,7 +436,7 @@ function synthesizeHeaders(headers: CustomHeaders, secret: SecretStorage): Recor
 	return Object.fromEntries(
 		headers.map(({ key, type, value }) => {
 			if (type === 'plaintext') return [key, value];
-			const secretValue = secret.getSecret(key);
+			const secretValue = secret.getSecret(value);
 			if (!secretValue) throw new Error(`Custom secret header not found: "${key}".`);
 			return [key, secretValue];
 		}),


### PR DESCRIPTION
synthesizeHeaders looked the keychain up with the header name (key) instead of the SecretComponent handle (value) so any secret custom header throws Custom secret header not found and breaks check connection and every sync via createRemoteFs

Resolves #236 